### PR TITLE
change fragment_length default in generate_fragment_memory from 9 to …

### DIFF
--- a/openawsem/scripts/mm_create_project.py
+++ b/openawsem/scripts/mm_create_project.py
@@ -271,7 +271,7 @@ class AWSEMSimulationProject:
 
         openawsem.helperFunctions.create_zim(f"crystal_structure.fasta", tableLocation=__location__/"helperFunctions")
 
-    def generate_fragment_memory(self,database = "cullpdb_pc80_res3.0_R1.0_d160504_chains29712",fasta = None,N_mem = 20,brain_damage = 1.0,fragmentLength = 9,cutoff_identical=90):
+    def generate_fragment_memory(self,database = "cullpdb_pc80_res3.0_R1.0_d160504_chains29712",fasta = None,N_mem = 20,brain_damage = 1.0,fragmentLength = 10,cutoff_identical=90):
         """
         Generate the fragment memory file if the frag option is specified.
         """


### PR DESCRIPTION
…10. This does not affect any behavior when the script is used as intended because this function parameter is overridden by the --frag_fragmentLength command line argument (or its default value of 10). However, the change may prevent future developer confusion