### PR TITLE
discard structurally mismatched fragmems

### DIFF
--- a/openawsem/helperFunctions/myFunctions.py
+++ b/openawsem/helperFunctions/myFunctions.py
@@ -305,14 +305,33 @@ def compute_theta_for_each_helix(output="angles.csv", dumpName="../dump.lammpstr
 
 
 
-def check_and_correct_fragment_memory(fragFile="fragsLAMW.mem"):
+def check_and_correct_fragment_memory(fragFile="fragsLAMW.mem",fragmem_structure=None,openawsem_location='.'): # typically, called with fragFile='frags.mem'
+    if fragmem_structure:
+        import MDAnalysis as mda
+        from MDAnalysis.analysis import align
+        fragmem_structure_u = mda.Universe(fragmem_structure)
     with open("tmp.mem", "w") as out:
-        with open(fragFile, "r") as f:
-            for i in range(4):
+        with open(fragFile, "r") as f: 
+            for i in range(4): # this takes care of the target query header thing
                 line = next(f)
                 out.write(line)
             for line in f:
-                gro, _, i, n, _ = line.split()
+                # assuming that our fasta file for the sequence that we want to build and fold is the same length
+                # as the fragmem_structure, so that there is a one to one mapping of indices in the fragFile to our fragmem_structure
+                # fragFile start indices are 1-indexed, and so are residue numbers in gro files, so the mapping makes no change to the index
+                gro, our_protein_start, i, n, _ = line.split() # n is number of residues, i is start residue (determined by index in fragFile)
+                our_protein_start = int(our_protein_start)
+                n = int(n)
+                i = int(i)
+                chain = gro.split('.')[-2][-1].upper()
+                # it is okay to access the installation-wide data base here because we are still in the awsem_create stage before
+                # anything has been copied over to the project fraglib directory
+                pdb = f"{openawsem_location}/data/PDBs/{gro.split('/')[-1][:4].upper()}.pdb" # assuming CODECHAIN.gro filename format for gros
+                assert os.path.isfile(pdb), f"PDB NOT FOUND: {pdb}"
+                # are there any differences between PDB and gro files? pdb2gro.py can potentially modify residue numbers and atom numbers
+                # by skipping over some residues that do not satisfy is_regular_res, for example.
+                # also, pdb2gro.py will just take the first altLoc listed in the file for atoms with multiple positions,
+                # except the case which Wei has documented below 
                 delete = False
                 # logging.info(f"{gro}, {i}, {n}")
                 # name = gro.split("/")[-1]
@@ -350,6 +369,52 @@ def check_and_correct_fragment_memory(fragFile="fragsLAMW.mem"):
                             delete = True
                         if test not in all_residues:
                             logging.warning(f"ATTENTION: {gro} {i} {n} missing: {test}")
+                            delete = True              
+                if fragmem_structure and not delete:
+                    print(f'PDB testing: {pdb}')
+                    # MDAnalysis resid follows numbering in topology file, with first:last being inclusive of both endpoints
+                    fragmem_structure_segment = fragmem_structure_u.select_atoms(f'resid {our_protein_start}:{our_protein_start+n-1} and name CA')
+                    to_delete = []
+                    current_structure_segment = mda.Universe(pdb).select_atoms(f'resid {i}:{i+n-1} and name CA and segid {chain}')
+                    for counter1 in range(len(current_structure_segment)):
+                        for counter2 in range(counter1+1, len(current_structure_segment)):
+                            if current_structure_segment[counter1].resid == current_structure_segment[counter2].resid:
+                                to_delete.append(counter2)
+                    current_structure_segment -= current_structure_segment[to_delete] # take only the first occurance of atoms with altLocs
+                    #current_structure_segment = mda.Universe(pdb).select_atoms(f'resid {i}:{i+n-1} and name CA and segid {chain}')
+                    # i don't think it's possible to do empty string or A for altLoc selection
+                    # if we get altLoc D or something like that it would be annoying, but should throw an error so it's not dangerous
+                    try:
+                        # align.alignto uses syntax (mobile, ref), so we're moving the structure containing the hit onto the appropriate region
+                        # of our target structure (the "fragmem" structure)
+                        old_rmsd, new_rmsd = align.alignto(current_structure_segment, fragmem_structure_segment,strict=True)
+                    except Exception as e:
+                        print(f"fragmem_structure_segment: {fragmem_structure_segment.atoms}")
+                        print(f"current_structure_segment: {current_structure_segment.atoms}")
+                        if "Reference and trajectory atom selections do not contain the same number of atoms" in str(e) and "and also not the same number of residues" in str(e):
+                            # in the future, we can put alternative error handling here if needed. 
+                            #print("PROBABLE MISSING RESIDUES IN FRAGMENT MEMORY. PRINTING MESSAGE BELOW AND WILL DELETE THIS MEMORY")
+                            raise
+                            #delete = True
+                        else:
+                            raise
+                    else: # try-except-else
+                        coords = fragmem_structure_segment.positions 
+                        distance_matrix = np.zeros([coords.shape[0],coords.shape[0]])
+                        native_distance_matrix = np.zeros([coords.shape[0],coords.shape[0]])
+                        for i in range(coords.shape[0]):
+                            for j in range(i+3,coords.shape[0]): # j > i+2
+                                distance_matrix[i,j] = np.linalg.norm(coords[i,:] - coords[j,:])
+                                native_distance_matrix[i,j] = np.linalg.norm(current_structure_segment.positions[i,:]-current_structure_segment.positions[j,:])
+                        diff_weights = native_distance_matrix - distance_matrix
+                        for i in range(diff_weights.shape[0]):
+                            for j in range(i+3,diff_weights.shape[1]): # j > i+2
+                                diff_weights[i,j] = np.exp(-(diff_weights[i,j]**2)/(2*((abs(i-j)**.15)**2)))
+                        q = (2/((diff_weights.shape[0]-2)*(diff_weights.shape[1]-3))) * np.sum(diff_weights)
+                        if '1R69' not in pdb and '1r69' not in pdb:
+                            assert 0 < new_rmsd < old_rmsd, f"new_rmsd: {new_rmsd}, old_rmsd: {old_rmsd}"
+                        #if new_rmsd > 2: # throw out fragmems that are structurally dissimilar to protein design target
+                        if q < 0.6:
                             delete = True
                 if not delete:
                     out.write(line)

--- a/openawsem/scripts/mm_create_project.py
+++ b/openawsem/scripts/mm_create_project.py
@@ -271,7 +271,7 @@ class AWSEMSimulationProject:
 
         openawsem.helperFunctions.create_zim(f"crystal_structure.fasta", tableLocation=__location__/"helperFunctions")
 
-    def generate_fragment_memory(self,database = "cullpdb_pc80_res3.0_R1.0_d160504_chains29712",fasta = None,N_mem = 20,brain_damage = 1.0,fragmentLength = 9,cutoff_identical=90):
+    def generate_fragment_memory(self,database = "cullpdb_pc80_res3.0_R1.0_d160504_chains29712",fasta = None,N_mem = 20,brain_damage = 1.0,fragmentLength = 10,cutoff_identical=90,fragmem_structure=None):
         """
         Generate the fragment memory file if the frag option is specified.
         """
@@ -291,7 +291,8 @@ class AWSEMSimulationProject:
         # ], stdout="logfile")
 
         # Check and correct the fragment memory file
-        openawsem.helperFunctions.check_and_correct_fragment_memory("frags.mem")
+        openawsem.helperFunctions.check_and_correct_fragment_memory("frags.mem",
+                        fragmem_structure=fragmem_structure,openawsem_location=__location__)
 
         # Relocate the file to the fraglib folder
         openawsem.helperFunctions.relocate(fileLocation="frags.mem", toLocation="fraglib")
@@ -395,7 +396,7 @@ class AWSEMSimulationProject:
 
                 # Generate fragment memory files if the frag option is enabled
                 if self.args.frag:
-                    self.generate_fragment_memory(database=self.args.frag_database, fasta=self.args.frag_fasta, N_mem=self.args.frag_N_mem, brain_damage=self.args.frag_brain_damage, fragmentLength=self.args.frag_fragmentLength, cutoff_identical=self.args.frag_cutoff_identical)
+                    self.generate_fragment_memory(database=self.args.frag_database, fasta=self.args.frag_fasta, N_mem=self.args.frag_N_mem, brain_damage=self.args.frag_brain_damage, fragmentLength=self.args.frag_fragmentLength, cutoff_identical=self.args.frag_cutoff_identical, fragmem_structure=self.args.frag_fragmem_structure)
 
                 #Generate charges
                 self.generate_charges()
@@ -496,6 +497,7 @@ def main(args=None):
 
       # Create a subparser for frag-related arguments
     frag_parser = parser.add_argument_group("frag", "Arguments for fragment memory generation. Only used if --frag is specified")
+    frag_parser.add_argument("--frag_fragmem_structure", default=None, help='known structure to filter out fragmems corresponding to non-native conformations')
     frag_parser.add_argument("--frag_database", default=openawsem.data_path.blast, help="Specify the database for fragment generation.")
     frag_parser.add_argument("--frag_fasta", default=None, help="Provide the FASTA file for fragment generation.")
     frag_parser.add_argument("--frag_N_mem", type=int, default=20, help="Number of memories to generate per fragment.")


### PR DESCRIPTION
We shouldn't need a continuing feature branch because this discarding mismatched fragmems is completely optional. Currently, it is implemented in check_and_correct_fragment_memory in myFunctions.py, but we talked about eventually moving it to create_fragment_memory.
