### PR TITLE
Parallelize hb init

### DIFF
--- a/openawsem/functionTerms/hydrogenBondTerms.py
+++ b/openawsem/functionTerms/hydrogenBondTerms.py
@@ -871,27 +871,6 @@ def _beta_efficiency_optimized(oa, term_number, ssweight_file, forceGroup, k_bet
         for future in as_completed(futures):
             i, lambda_row = future.result()
             lambda_term_number[i, :] = lambda_row
-    """
-    for i in range(nres):
-        for j in range(nres):
-            if 4<=abs(i-j)<18 and inSameChain(i,j,oa.chain_starts,oa.chain_ends) and not (rama_biases[i][1] and rama_biases[j][1]): # in same chain, seqsep<18, not both beta
-                lambda_term_number[i][j] = 0
-            else:
-                if term_number == 1:
-                    lambda_term_number[i][j] = get_lambda_by_index(i, j, 0, oa.chain_starts,oa.chain_ends)
-                elif term_number == 2:
-                    if isChainEdge(i,oa.chain_starts,oa.chain_ends,n=1) or isChainEdge(j,oa.chain_starts,oa.chain_ends,n=1):
-                        continue # i+1 or i-1 or j+1 or j-1 don't exist so we won't be able to get a[i-1] and/or a[i+1] and/or a[j-1] and/or a[j+1]
-                                 # such groups end up not being added to the potential anyway (see below), but this is needed to get the code to run
-                    lambda_term_number[i][j] = get_Lambda_2(i, j, p_par, p_anti, p_antihb, p_antinhb, p_parhb, a, oa.chain_starts, oa.chain_ends)
-                elif term_number == 3:
-                    if isChainEnd(i,oa.chain_ends,n=1):
-                        continue # i+1 doesn't exist so we won't be able to get a[i+1]
-                                 # such groups end up not being added to the potential anyway (see below), but this is needed to get the code to run
-                    lambda_term_number[i][j] = get_Lambda_3(i, j, p_par, p_anti, p_antihb, p_antinhb, p_parhb, a, oa.chain_starts, oa.chain_ends)
-                else:
-                    raise ValueError(f"term_number must be 1, 2, or 3, but was {term_number}")
-    """
     #
     # define energy functions
     theta_ij =   f"exp(-(r_Oi_Nj-{r_ON})^2/(2*{sigma_NO}^2)-(r_Oi_Hj-{r_OH})^2/(2*{sigma_HO}^2))"


### PR DESCRIPTION
## Description
HB initialization needs to loop over all pairs of residues i and j, which can be slow for big systems. This PR parallelizes (on the CPU) the initialization.

## Todos

## Questions
None

## Status
- [x] Passes HB term pytests