### PR TITLE
Update atomic masses for CA, O, and CB types

### DIFF
--- a/openawsem/topology/awsem.xml
+++ b/openawsem/topology/awsem.xml
@@ -3,10 +3,10 @@
 <AtomTypes>
  <Type name="N" class="N" element="N" mass="0"/>
  <Type name="H" class="H" element="H" mass="0"/>
- <Type name="CA" class="CA" element="C" mass="12"/>
+ <Type name="CA" class="CA" element="C" mass="27"/>
  <Type name="C" class="C" element="C" mass="0"/>
- <Type name="O" class="O" element="O" mass="16"/>
- <Type name="CB" class="CB" element="B" mass="12"/>
+ <Type name="O" class="O" element="O" mass="28"/>
+ <Type name="CB" class="CB" element="B" mass="60"/>
 
 </AtomTypes>
 


### PR DESCRIPTION
Makes masses more consistent with LAMMPS AWSEM-MD (not exactly the same because we don't have H-Beta for glycine). I don't know if it's "wrong" to use the 12/16/12 masses that we were using in OpenAWSEM up to this point, but it was to my knowledge never done in AWSEM-MD, so maybe the 27/28/60 masses should be the default here