### PR TITLE
delete bonds from the topology after it is created by PDBFile

### DIFF
--- a/openawsem/openAWSEM.py
+++ b/openawsem/openAWSEM.py
@@ -850,6 +850,7 @@ class OpenMMAWSEMSystem:
         else:
             self.fixed_atom_indices = []
         if not includeLigands:
+            self._pdb.topology._bonds = [] # we need to think about this some more
             self.system = self.forcefield.createSystem(self.pdb.topology)
             # define convenience variables
             self.nres = self.pdb.topology.getNumResidues()


### PR DESCRIPTION
## Description
We need to verify that this doesn't break anything, but in the long run this should reduce the chances of unexpected behavior and enable using standard 3 letter codes in -openmmawsem.pdb files

## Todos
  - [ ] Simplify topology processing: it will only have the Bonds that we explicitly add

## Questions
- [ ] Need to verify that nothing relies on the Bonds created by PDBFile

## Status
- [ ] Ready to go